### PR TITLE
feat: add get_commands and get_completions tools

### DIFF
--- a/packages/vscode-mcp-bridge/src/extension.ts
+++ b/packages/vscode-mcp-bridge/src/extension.ts
@@ -1,6 +1,8 @@
 import {
     ExecuteCommandInputSchema,
     ExecuteCommandOutputSchema,
+    GetCommandsInputSchema,
+    GetCommandsOutputSchema,
     GetDiagnosticsInputSchema,
     GetDiagnosticsOutputSchema,
     GetReferencesInputSchema,
@@ -25,7 +27,8 @@ import { sleepCommand } from './commands/sleep';
 import { logger } from './logger';
 import {
     executeCommand,
-getCurrentWorkspacePath,
+    getCommands,
+    getCurrentWorkspacePath,
     getDiagnostics,
     getReferences,
     getSymbolLSPInfo,
@@ -109,7 +112,13 @@ export async function activate(context: vscode.ExtensionContext) {
             handler: listWorkspaces,
             resultSchema: ListWorkspacesOutputSchema
         });
-        
+
+        socketServer.register('getCommands', {
+            handler: getCommands,
+            payloadSchema: GetCommandsInputSchema,
+            resultSchema: GetCommandsOutputSchema
+        });
+
         // Start socket server
         await socketServer.start();
         

--- a/packages/vscode-mcp-bridge/src/extension.ts
+++ b/packages/vscode-mcp-bridge/src/extension.ts
@@ -3,6 +3,8 @@ import {
     ExecuteCommandOutputSchema,
     GetCommandsInputSchema,
     GetCommandsOutputSchema,
+    GetCompletionsInputSchema,
+    GetCompletionsOutputSchema,
     GetDiagnosticsInputSchema,
     GetDiagnosticsOutputSchema,
     GetReferencesInputSchema,
@@ -28,6 +30,7 @@ import { logger } from './logger';
 import {
     executeCommand,
     getCommands,
+    getCompletions,
     getCurrentWorkspacePath,
     getDiagnostics,
     getReferences,
@@ -117,6 +120,12 @@ export async function activate(context: vscode.ExtensionContext) {
             handler: getCommands,
             payloadSchema: GetCommandsInputSchema,
             resultSchema: GetCommandsOutputSchema
+        });
+
+        socketServer.register('getCompletions', {
+            handler: getCompletions,
+            payloadSchema: GetCompletionsInputSchema,
+            resultSchema: GetCompletionsOutputSchema
         });
 
         // Start socket server

--- a/packages/vscode-mcp-bridge/src/services/get-commands.ts
+++ b/packages/vscode-mcp-bridge/src/services/get-commands.ts
@@ -1,0 +1,36 @@
+import type { EventParams, EventResult } from '@vscode-mcp/vscode-mcp-ipc';
+import * as vscode from 'vscode';
+
+/**
+ * Get all available VSCode commands with pagination
+ */
+export const getCommands = async (
+    payload: EventParams<'getCommands'>
+): Promise<EventResult<'getCommands'>> => {
+    const { filterInternal, pattern, offset, limit } = payload;
+    const maxLimit = Math.min(limit, 500);
+
+    // Get all commands
+    let allCommands = await vscode.commands.getCommands(filterInternal);
+
+    // Apply pattern filter if provided
+    if (pattern) {
+        const regex = new RegExp(pattern, 'i');
+        allCommands = allCommands.filter((cmd: string) => regex.test(cmd));
+    }
+
+    // Sort alphabetically
+    allCommands.sort();
+
+    const total = allCommands.length;
+    const paginatedCommands = allCommands.slice(offset, offset + maxLimit);
+    const hasMore = offset + maxLimit < total;
+
+    return {
+        commands: paginatedCommands,
+        total,
+        offset,
+        limit: maxLimit,
+        hasMore,
+    };
+};

--- a/packages/vscode-mcp-bridge/src/services/get-completions.ts
+++ b/packages/vscode-mcp-bridge/src/services/get-completions.ts
@@ -1,0 +1,134 @@
+import type { EventParams, EventResult } from '@vscode-mcp/vscode-mcp-ipc';
+import * as vscode from 'vscode';
+
+import { ensureFileIsOpen, resolveFilePath } from '../utils/workspace.js';
+
+/**
+ * Completion item shape for output
+ */
+interface CompletionItemOutput {
+    label: string;
+    kind?: string;
+    detail?: string;
+    documentation?: string;
+    insertText?: string;
+    sortText?: string;
+    filterText?: string;
+}
+
+/**
+ * Map VSCode CompletionItemKind to string
+ */
+const completionKindMap: Record<number, CompletionItemOutput['kind']> = {
+    [vscode.CompletionItemKind.Text]: 'Text',
+    [vscode.CompletionItemKind.Method]: 'Method',
+    [vscode.CompletionItemKind.Function]: 'Function',
+    [vscode.CompletionItemKind.Constructor]: 'Constructor',
+    [vscode.CompletionItemKind.Field]: 'Field',
+    [vscode.CompletionItemKind.Variable]: 'Variable',
+    [vscode.CompletionItemKind.Class]: 'Class',
+    [vscode.CompletionItemKind.Interface]: 'Interface',
+    [vscode.CompletionItemKind.Module]: 'Module',
+    [vscode.CompletionItemKind.Property]: 'Property',
+    [vscode.CompletionItemKind.Unit]: 'Unit',
+    [vscode.CompletionItemKind.Value]: 'Value',
+    [vscode.CompletionItemKind.Enum]: 'Enum',
+    [vscode.CompletionItemKind.Keyword]: 'Keyword',
+    [vscode.CompletionItemKind.Snippet]: 'Snippet',
+    [vscode.CompletionItemKind.Color]: 'Color',
+    [vscode.CompletionItemKind.File]: 'File',
+    [vscode.CompletionItemKind.Reference]: 'Reference',
+    [vscode.CompletionItemKind.Folder]: 'Folder',
+    [vscode.CompletionItemKind.EnumMember]: 'EnumMember',
+    [vscode.CompletionItemKind.Constant]: 'Constant',
+    [vscode.CompletionItemKind.Struct]: 'Struct',
+    [vscode.CompletionItemKind.Event]: 'Event',
+    [vscode.CompletionItemKind.Operator]: 'Operator',
+    [vscode.CompletionItemKind.TypeParameter]: 'TypeParameter',
+};
+
+/**
+ * Get code completions at a specific position in a file
+ */
+export const getCompletions = async (
+    payload: EventParams<'getCompletions'>
+): Promise<EventResult<'getCompletions'>> => {
+    const { filePath, line, character, triggerCharacter, offset, limit } = payload;
+    const maxLimit = Math.min(limit, 100);
+
+    const uri = resolveFilePath(filePath);
+    const position = new vscode.Position(line, character);
+
+    // Ensure file is open for accurate completions
+    await ensureFileIsOpen(uri.toString());
+
+    // Execute completion provider
+    const completionList = await vscode.commands.executeCommand<vscode.CompletionList | vscode.CompletionItem[]>(
+        'vscode.executeCompletionItemProvider',
+        uri,
+        position,
+        triggerCharacter
+    );
+
+    // Normalize to array
+    let allItems: vscode.CompletionItem[];
+    let isIncomplete = false;
+
+    if (!completionList) {
+        allItems = [];
+    } else if (Array.isArray(completionList)) {
+        allItems = completionList;
+    } else {
+        allItems = completionList.items;
+        isIncomplete = completionList.isIncomplete;
+    }
+
+    const total = allItems.length;
+
+    // Apply pagination
+    const paginatedItems = allItems.slice(offset, offset + maxLimit);
+    const hasMore = offset + maxLimit < total;
+
+    // Transform to our schema
+    const items: CompletionItemOutput[] = paginatedItems.map((item) => {
+        const label = typeof item.label === 'string' ? item.label : item.label.label;
+        const detail = typeof item.label === 'object' ? item.label.detail : item.detail;
+
+        let documentation: string | undefined;
+        if (item.documentation) {
+            if (typeof item.documentation === 'string') {
+                documentation = item.documentation;
+            } else {
+                documentation = item.documentation.value;
+            }
+        }
+
+        let insertText: string | undefined;
+        if (item.insertText) {
+            if (typeof item.insertText === 'string') {
+                insertText = item.insertText;
+            } else {
+                insertText = item.insertText.value;
+            }
+        }
+
+        return {
+            label,
+            kind: item.kind !== undefined ? completionKindMap[item.kind] : undefined,
+            detail,
+            documentation,
+            insertText,
+            sortText: item.sortText,
+            filterText: item.filterText,
+        };
+    });
+
+    return {
+        items,
+        total,
+        offset,
+        limit: maxLimit,
+        hasMore,
+        isIncomplete,
+    };
+};

--- a/packages/vscode-mcp-bridge/src/services/index.ts
+++ b/packages/vscode-mcp-bridge/src/services/index.ts
@@ -1,6 +1,7 @@
 // Export service functions
 export { executeCommand } from './execute-command';
 export { getCommands } from './get-commands';
+export { getCompletions } from './get-completions';
 export { getDiagnostics } from './get-diagnostics';
 export { getReferences } from './get-references';
 export { getSymbolLSPInfo } from './get-symbol-lsp-info';

--- a/packages/vscode-mcp-bridge/src/services/index.ts
+++ b/packages/vscode-mcp-bridge/src/services/index.ts
@@ -1,5 +1,6 @@
 // Export service functions
 export { executeCommand } from './execute-command';
+export { getCommands } from './get-commands';
 export { getDiagnostics } from './get-diagnostics';
 export { getReferences } from './get-references';
 export { getSymbolLSPInfo } from './get-symbol-lsp-info';

--- a/packages/vscode-mcp-ipc/src/events/get-commands.ts
+++ b/packages/vscode-mcp-ipc/src/events/get-commands.ts
@@ -1,0 +1,36 @@
+/**
+ * Get commands event types and schemas
+ */
+
+import { z } from 'zod';
+
+/**
+ * Get commands input schema
+ */
+export const GetCommandsInputSchema = z.object({
+  filterInternal: z.boolean().optional().default(true).describe('Filter out internal commands (starting with _)'),
+  pattern: z.string().optional().describe('Optional regex pattern to filter commands'),
+  offset: z.number().optional().default(0).describe('Pagination offset'),
+  limit: z.number().optional().default(100).describe('Number of commands per page (max 500)'),
+}).strict();
+
+/**
+ * Get commands output schema
+ */
+export const GetCommandsOutputSchema = z.object({
+  commands: z.array(z.string()).describe('List of command IDs'),
+  total: z.number().describe('Total number of commands matching filter'),
+  offset: z.number().describe('Current offset'),
+  limit: z.number().describe('Current limit'),
+  hasMore: z.boolean().describe('Whether there are more commands'),
+}).strict();
+
+/**
+ * Get commands payload (input parameters)
+ */
+export type GetCommandsPayload = z.infer<typeof GetCommandsInputSchema>;
+
+/**
+ * Get commands result (output data)
+ */
+export type GetCommandsResult = z.infer<typeof GetCommandsOutputSchema>;

--- a/packages/vscode-mcp-ipc/src/events/get-completions.ts
+++ b/packages/vscode-mcp-ipc/src/events/get-completions.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+/**
+ * Input schema for getCompletions event
+ */
+export const GetCompletionsInputSchema = z.object({
+  /** File path (absolute or relative to workspace root) */
+  filePath: z.string().describe('File path (absolute or relative to workspace root)'),
+  /** Line number (0-indexed) */
+  line: z.number().int().min(0).describe('Line number (0-indexed)'),
+  /** Character position (0-indexed) */
+  character: z.number().int().min(0).describe('Character position (0-indexed)'),
+  /** Optional trigger character (e.g., '.', '(', '<') */
+  triggerCharacter: z.string().optional().describe('Optional trigger character'),
+  /** Pagination offset (default: 0) */
+  offset: z.number().int().min(0).optional().default(0).describe('Pagination offset'),
+  /** Number of items per page, max 100 (default: 50) */
+  limit: z.number().int().min(1).max(100).optional().default(50).describe('Number of items per page'),
+}).strict();
+
+/**
+ * Completion item kind (matches VSCode CompletionItemKind)
+ */
+export const CompletionItemKindEnum = z.enum([
+  'Text', 'Method', 'Function', 'Constructor', 'Field', 'Variable',
+  'Class', 'Interface', 'Module', 'Property', 'Unit', 'Value',
+  'Enum', 'Keyword', 'Snippet', 'Color', 'File', 'Reference',
+  'Folder', 'EnumMember', 'Constant', 'Struct', 'Event', 'Operator', 'TypeParameter'
+]);
+
+/**
+ * Single completion item
+ */
+export const CompletionItemSchema = z.object({
+  /** The label of this completion item */
+  label: z.string(),
+  /** The kind of this completion item */
+  kind: CompletionItemKindEnum.optional(),
+  /** A human-readable string with additional information */
+  detail: z.string().optional(),
+  /** A human-readable string that represents a doc-comment */
+  documentation: z.string().optional(),
+  /** A string that should be inserted when selecting this completion */
+  insertText: z.string().optional(),
+  /** Sort text used for sorting completions */
+  sortText: z.string().optional(),
+  /** Filter text used for filtering completions */
+  filterText: z.string().optional(),
+});
+
+/**
+ * Output schema for getCompletions event
+ */
+export const GetCompletionsOutputSchema = z.object({
+  /** Array of completion items for current page */
+  items: z.array(CompletionItemSchema),
+  /** Total number of completions available */
+  total: z.number(),
+  /** Current offset */
+  offset: z.number(),
+  /** Current limit */
+  limit: z.number(),
+  /** Whether there are more items */
+  hasMore: z.boolean(),
+  /** Whether completions are incomplete (may have more from language server) */
+  isIncomplete: z.boolean(),
+}).strict();
+
+export type GetCompletionsPayload = z.infer<typeof GetCompletionsInputSchema>;
+export type GetCompletionsResult = z.infer<typeof GetCompletionsOutputSchema>;
+export type CompletionItem = z.infer<typeof CompletionItemSchema>;

--- a/packages/vscode-mcp-ipc/src/events/index.ts
+++ b/packages/vscode-mcp-ipc/src/events/index.ts
@@ -1,6 +1,7 @@
 // Import all event modules
 import type { ExecuteCommandPayload, ExecuteCommandResult } from './execute-command.js';
 import type { GetCommandsPayload, GetCommandsResult } from './get-commands.js';
+import type { GetCompletionsPayload, GetCompletionsResult } from './get-completions.js';
 import type { GetDiagnosticsPayload, GetDiagnosticsResult } from './get-diagnostics.js';
 import type { GetReferencesPayload, GetReferencesResult } from './get-references.js';
 import type { GetSymbolLSPInfoPayload, GetSymbolLSPInfoResult } from './get-symbol-lsp-info.js';
@@ -13,6 +14,7 @@ import type { RenameSymbolPayload, RenameSymbolResult } from './rename-symbol.js
 export * from '../common.js';
 export * from './execute-command.js';
 export * from './get-commands.js';
+export * from './get-completions.js';
 export * from './get-diagnostics.js';
 export * from './get-references.js';
 export * from './get-symbol-lsp-info.js';
@@ -103,6 +105,12 @@ export interface EventMap {
   getCommands: {
     params: GetCommandsPayload;
     result: GetCommandsResult;
+  };
+
+  /** Get code completions at position */
+  getCompletions: {
+    params: GetCompletionsPayload;
+    result: GetCompletionsResult;
   };
 }
 

--- a/packages/vscode-mcp-ipc/src/events/index.ts
+++ b/packages/vscode-mcp-ipc/src/events/index.ts
@@ -1,5 +1,6 @@
 // Import all event modules
 import type { ExecuteCommandPayload, ExecuteCommandResult } from './execute-command.js';
+import type { GetCommandsPayload, GetCommandsResult } from './get-commands.js';
 import type { GetDiagnosticsPayload, GetDiagnosticsResult } from './get-diagnostics.js';
 import type { GetReferencesPayload, GetReferencesResult } from './get-references.js';
 import type { GetSymbolLSPInfoPayload, GetSymbolLSPInfoResult } from './get-symbol-lsp-info.js';
@@ -11,6 +12,7 @@ import type { RenameSymbolPayload, RenameSymbolResult } from './rename-symbol.js
 // Re-export all event types and schemas
 export * from '../common.js';
 export * from './execute-command.js';
+export * from './get-commands.js';
 export * from './get-diagnostics.js';
 export * from './get-references.js';
 export * from './get-symbol-lsp-info.js';
@@ -95,6 +97,12 @@ export interface EventMap {
   listWorkspaces: {
     params: ListWorkspacesPayload;
     result: ListWorkspacesResult;
+  };
+
+  /** Get all available commands */
+  getCommands: {
+    params: GetCommandsPayload;
+    result: GetCommandsResult;
   };
 }
 

--- a/packages/vscode-mcp-server/src/constants.ts
+++ b/packages/vscode-mcp-server/src/constants.ts
@@ -6,6 +6,7 @@
  */
 export enum VscodeMcpToolName {
   EXECUTE_COMMAND = 'execute_command',
+  GET_COMMANDS = 'get_commands',
   GET_DIAGNOSTICS = 'get_diagnostics',
   GET_REFERENCES = 'get_references',
   GET_SYMBOL_LSP_INFO = 'get_symbol_lsp_info',

--- a/packages/vscode-mcp-server/src/constants.ts
+++ b/packages/vscode-mcp-server/src/constants.ts
@@ -7,6 +7,7 @@
 export enum VscodeMcpToolName {
   EXECUTE_COMMAND = 'execute_command',
   GET_COMMANDS = 'get_commands',
+  GET_COMPLETIONS = 'get_completions',
   GET_DIAGNOSTICS = 'get_diagnostics',
   GET_REFERENCES = 'get_references',
   GET_SYMBOL_LSP_INFO = 'get_symbol_lsp_info',

--- a/packages/vscode-mcp-server/src/server.ts
+++ b/packages/vscode-mcp-server/src/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { VscodeMcpToolName } from "./constants.js";
 import {
   registerExecuteCommand,
+  registerGetCommands,
   registerGetDiagnostics,
   registerGetReferences,
   registerGetSymbolLSPInfo,
@@ -17,6 +18,7 @@ type ToolRegistrationFunction = (server: McpServer, ...args: any[]) => void;
 
 const TOOL_REGISTRY: Record<string, ToolRegistrationFunction> = {
   [VscodeMcpToolName.HEALTH_CHECK]: (server: McpServer, version: string) => registerHealthCheck(server, version),
+  [VscodeMcpToolName.GET_COMMANDS]: registerGetCommands,
   [VscodeMcpToolName.GET_DIAGNOSTICS]: registerGetDiagnostics,
   [VscodeMcpToolName.GET_SYMBOL_LSP_INFO]: registerGetSymbolLSPInfo,
   [VscodeMcpToolName.GET_REFERENCES]: registerGetReferences,

--- a/packages/vscode-mcp-server/src/server.ts
+++ b/packages/vscode-mcp-server/src/server.ts
@@ -4,6 +4,7 @@ import { VscodeMcpToolName } from "./constants.js";
 import {
   registerExecuteCommand,
   registerGetCommands,
+  registerGetCompletions,
   registerGetDiagnostics,
   registerGetReferences,
   registerGetSymbolLSPInfo,
@@ -19,6 +20,7 @@ type ToolRegistrationFunction = (server: McpServer, ...args: any[]) => void;
 const TOOL_REGISTRY: Record<string, ToolRegistrationFunction> = {
   [VscodeMcpToolName.HEALTH_CHECK]: (server: McpServer, version: string) => registerHealthCheck(server, version),
   [VscodeMcpToolName.GET_COMMANDS]: registerGetCommands,
+  [VscodeMcpToolName.GET_COMPLETIONS]: registerGetCompletions,
   [VscodeMcpToolName.GET_DIAGNOSTICS]: registerGetDiagnostics,
   [VscodeMcpToolName.GET_SYMBOL_LSP_INFO]: registerGetSymbolLSPInfo,
   [VscodeMcpToolName.GET_REFERENCES]: registerGetReferences,

--- a/packages/vscode-mcp-server/src/tools/get-commands.ts
+++ b/packages/vscode-mcp-server/src/tools/get-commands.ts
@@ -1,0 +1,61 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createDispatcher, GetCommandsInputSchema } from "@vscode-mcp/vscode-mcp-ipc";
+
+import { VscodeMcpToolName } from "../constants.js";
+import { formatToolCallError } from "../utils/format-tool-call-error.js";
+import { workspacePathInputSchema } from "../utils/workspace-schema.js";
+
+const inputSchema = {
+  ...workspacePathInputSchema,
+  ...GetCommandsInputSchema.shape
+};
+
+const DESCRIPTION = `Get all available VSCode commands with pagination support.
+
+**Use Cases:**
+- Explore available VSCode commands
+- Find commands matching a pattern
+- Browse commands page by page
+
+**Parameters:**
+- filterInternal: Filter out internal commands starting with _ (default: true)
+- pattern: Optional regex pattern to filter commands (e.g., "editor", "workbench")
+- offset: Pagination offset (default: 0)
+- limit: Number of commands per page, max 500 (default: 100)
+
+**Returns:**
+- commands: Array of command IDs for current page
+- total: Total number of commands matching filter
+- offset: Current offset
+- limit: Current limit
+- hasMore: Whether there are more commands
+`;
+
+export function registerGetCommands(server: McpServer) {
+  server.registerTool(VscodeMcpToolName.GET_COMMANDS, {
+    title: "Get Commands",
+    description: DESCRIPTION,
+    inputSchema,
+    annotations: {
+      title: "Get Commands",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  }, async ({ workspace_path, filterInternal, pattern, offset, limit }) => {
+    try {
+      const dispatcher = await createDispatcher(workspace_path);
+      const result = await dispatcher.dispatch("getCommands", { filterInternal, pattern, offset, limit });
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(result, null, 2)
+        }]
+      };
+    } catch (error) {
+      return formatToolCallError("Get Commands", error);
+    }
+  });
+}

--- a/packages/vscode-mcp-server/src/tools/get-completions.ts
+++ b/packages/vscode-mcp-server/src/tools/get-completions.ts
@@ -1,0 +1,72 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createDispatcher, GetCompletionsInputSchema } from "@vscode-mcp/vscode-mcp-ipc";
+
+import { VscodeMcpToolName } from "../constants.js";
+import { formatToolCallError } from "../utils/format-tool-call-error.js";
+import { workspacePathInputSchema } from "../utils/workspace-schema.js";
+
+const inputSchema = {
+  ...workspacePathInputSchema,
+  ...GetCompletionsInputSchema.shape
+};
+
+const DESCRIPTION = `Get code completions at a specific position in a file.
+
+**Use Cases:**
+- Get autocomplete suggestions at cursor position
+- Discover available methods/properties after typing '.'
+- Find function parameters after typing '('
+- Explore available imports
+
+**Parameters:**
+- filePath: File path (absolute or relative to workspace root)
+- line: Line number (0-indexed)
+- character: Character position (0-indexed)
+- triggerCharacter: Optional trigger character (e.g., '.', '(', '<')
+- offset: Pagination offset (default: 0)
+- limit: Number of items per page, max 100 (default: 50)
+
+**Returns:**
+- items: Array of completion items with label, kind, detail, documentation, insertText
+- total: Total number of completions available
+- offset: Current offset
+- limit: Current limit
+- hasMore: Whether there are more items
+- isIncomplete: Whether completions are incomplete (language server may have more)
+`;
+
+export function registerGetCompletions(server: McpServer) {
+  server.registerTool(VscodeMcpToolName.GET_COMPLETIONS, {
+    title: "Get Completions",
+    description: DESCRIPTION,
+    inputSchema,
+    annotations: {
+      title: "Get Completions",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    }
+  }, async ({ workspace_path, filePath, line, character, triggerCharacter, offset, limit }) => {
+    try {
+      const dispatcher = await createDispatcher(workspace_path);
+      const result = await dispatcher.dispatch("getCompletions", {
+        filePath,
+        line,
+        character,
+        triggerCharacter,
+        offset,
+        limit
+      });
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(result, null, 2)
+        }]
+      };
+    } catch (error) {
+      return formatToolCallError("Get Completions", error);
+    }
+  });
+}

--- a/packages/vscode-mcp-server/src/tools/index.ts
+++ b/packages/vscode-mcp-server/src/tools/index.ts
@@ -10,6 +10,7 @@ export { formatToolCallError } from "../utils/format-tool-call-error.js";
 // 工具注册函数
 export { registerExecuteCommand } from "./execute-command.js";
 export { registerGetCommands } from "./get-commands.js";
+export { registerGetCompletions } from "./get-completions.js";
 export { registerGetDiagnostics } from "./get-diagnostics.js";
 export { registerGetReferences } from "./get-references.js";
 export { registerGetSymbolLSPInfo } from "./get-symbol-lsp-info.js";

--- a/packages/vscode-mcp-server/src/tools/index.ts
+++ b/packages/vscode-mcp-server/src/tools/index.ts
@@ -8,7 +8,8 @@
 export { formatToolCallError } from "../utils/format-tool-call-error.js";
 
 // 工具注册函数
-export { registerExecuteCommand } from "./execute-command.js"; 
+export { registerExecuteCommand } from "./execute-command.js";
+export { registerGetCommands } from "./get-commands.js";
 export { registerGetDiagnostics } from "./get-diagnostics.js";
 export { registerGetReferences } from "./get-references.js";
 export { registerGetSymbolLSPInfo } from "./get-symbol-lsp-info.js";


### PR DESCRIPTION
## Summary / 摘要

This PR adds two new MCP tools with pagination support:

本 PR 添加了两个支持分页的新 MCP 工具：

### 1. `get_commands`
- List all available VSCode commands / 列出所有可用的 VSCode 命令
- Filter by regex pattern / 支持正则表达式过滤
- Pagination with offset/limit (max 500) / 分页支持 offset/limit（最大 500）

### 2. `get_completions`
- Get code completions at cursor position / 获取光标位置的代码补全
- Support trigger characters (`.`, `(`, `<`) / 支持触发字符
- Pagination with offset/limit (max 100) / 分页支持 offset/limit（最大 100）
- Works with any LSP (TypeScript, clangd, etc.) / 适用于任何 LSP

## Use Cases / 使用场景

- **get_commands**: Discover available commands before using `execute_command`
- **get_commands**: 在使用 `execute_command` 前发现可用命令
- **get_completions**: Help AI coding assistants write code more accurately
- **get_completions**: 帮助 AI 编程助手更准确地编写代码

## Changes / 变更

- `vscode-mcp-ipc`: Added schemas for both tools / 添加了两个工具的 schema
- `vscode-mcp-bridge`: Added VSCode API services / 添加了 VSCode API 服务
- `vscode-mcp-server`: Added MCP tool registrations / 添加了 MCP 工具注册

## Test Plan / 测试计划

- [x] Tested `get_commands` with various patterns and pagination
- [x] Tested `get_completions` with TypeScript and C (clangd)
- [x] Verified pagination works correctly (hasMore flag)

---

🤖 Generated with [Claude Code](https://claude.ai/code)