### PR TITLE
fix: return disambiguation list instead of error on multiple symbol m…

### DIFF
--- a/packages/vscode-mcp-bridge/src/services/get-symbol-lsp-info.ts
+++ b/packages/vscode-mcp-bridge/src/services/get-symbol-lsp-info.ts
@@ -2,7 +2,7 @@ import type { EventParams, EventResult, LSPInfoType } from '@vscode-mcp/vscode-m
 import * as vscode from 'vscode';
 
 import { getUsageCode } from '../utils/get-usage-code.js';
-import { resolveSymbolPosition } from '../utils/resolve-symbol-position.js';
+import { resolveSymbolPosition, resolveSymbolPositionOrListMatches } from '../utils/resolve-symbol-position.js';
 import { ensureFileIsOpen, resolveFilePath } from '../utils/workspace.js';
 
 /**
@@ -50,9 +50,16 @@ export const getSymbolLSPInfo = async (
     // Ensure file is open to get accurate LSP information
     await ensureFileIsOpen(vscodeUri.toString());
     
-    // Resolve symbol to position
-    const position = await resolveSymbolPosition(vscodeUri, symbol, codeSnippet);
-    
+    // Resolve symbol to position (may return multiple matches for disambiguation)
+    const resolution = await resolveSymbolPositionOrListMatches(vscodeUri, symbol, codeSnippet);
+
+    // If multiple matches found, return them for disambiguation instead of erroring
+    if (resolution.type === 'multiple') {
+        return { multipleOccurrences: resolution.matches };
+    }
+
+    const position = resolution.position;
+
     const result: EventResult<'getSymbolLSPInfo'> = {};
     
     /**

--- a/packages/vscode-mcp-bridge/src/utils/resolve-symbol-position.ts
+++ b/packages/vscode-mcp-bridge/src/utils/resolve-symbol-position.ts
@@ -111,3 +111,50 @@ function findAllSymbolMatches(text: string, symbol: string, document: vscode.Tex
 function escapeRegExp(string: string): string {
     return string.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
+
+/**
+ * Result of symbol resolution that may contain multiple matches
+ */
+export type SymbolResolutionResult =
+    | { type: 'resolved'; position: vscode.Position }
+    | { type: 'multiple'; matches: Array<{ line: number; character: number; lineContent: string }> };
+
+/**
+ * Resolve symbol position, but instead of throwing on multiple matches,
+ * return all matches with their line context for disambiguation.
+ * Used by get_symbol_lsp_info to provide helpful responses.
+ */
+export async function resolveSymbolPositionOrListMatches(
+    uri: vscode.Uri,
+    symbol: string,
+    codeSnippet?: string
+): Promise<SymbolResolutionResult> {
+    const document = await vscode.workspace.openTextDocument(uri);
+    const text = document.getText();
+
+    if (codeSnippet) {
+        // With codeSnippet: delegate to existing logic (it throws on ambiguity, which is fine)
+        const position = findSymbolInCodeSnippet(text, symbol, codeSnippet, document);
+        return { type: 'resolved', position };
+    }
+
+    // No codeSnippet: find all matches
+    const positions = findAllSymbolMatches(text, symbol, document);
+
+    if (positions.length === 0) {
+        throw new Error(`Symbol "${symbol}" not found in file`);
+    }
+
+    if (positions.length === 1) {
+        return { type: 'resolved', position: positions[0] };
+    }
+
+    // Multiple matches: return them all with line context
+    const matches = positions.map(pos => ({
+        line: pos.line,
+        character: pos.character,
+        lineContent: document.lineAt(pos.line).text,
+    }));
+
+    return { type: 'multiple', matches };
+}

--- a/packages/vscode-mcp-ipc/src/events/get-symbol-lsp-info.ts
+++ b/packages/vscode-mcp-ipc/src/events/get-symbol-lsp-info.ts
@@ -70,12 +70,22 @@ export const GetSymbolLSPInfoInputSchema = SymbolLocatorSchema.extend({
 /**
  * Get symbol LSP info output schema
  */
+/**
+ * Symbol occurrence schema for disambiguation when multiple matches are found
+ */
+const SymbolOccurrenceSchema = z.object({
+  line: z.number().describe('0-indexed line number'),
+  character: z.number().describe('0-indexed character offset'),
+  lineContent: z.string().describe('Full text content of the line containing the match'),
+}).strict();
+
 export const GetSymbolLSPInfoOutputSchema = z.object({
   hover: z.array(HoverSchema).optional().describe('Hover information for the symbol'),
   signature_help: SignatureHelpSchema.nullable().optional().describe('Function signature help information'),
   type_definition: z.array(LocationSchema).optional().describe('Symbol type definition locations'),
   definition: z.array(LocationSchema).optional().describe('Symbol definition locations'),
   implementation: z.array(LocationSchema).optional().describe('Symbol implementation locations'),
+  multipleOccurrences: z.array(SymbolOccurrenceSchema).optional().describe('When multiple matches are found, lists all occurrences with context for disambiguation. Use codeSnippet parameter to select the correct one.'),
 }).strict();
 
 /**

--- a/packages/vscode-mcp-server/src/tools/get-symbol-lsp-info.ts
+++ b/packages/vscode-mcp-server/src/tools/get-symbol-lsp-info.ts
@@ -45,7 +45,26 @@ export function registerGetSymbolLSPInfo(server: McpServer) {
     try {
       const dispatcher = await createDispatcher(workspace_path);
       const result = await dispatcher.dispatch("getSymbolLSPInfo", { filePath, symbol, codeSnippet, infoType });
-      
+
+      // Handle multiple occurrences disambiguation
+      if (result.multipleOccurrences && result.multipleOccurrences.length > 0) {
+        let output = `⚠️ **Multiple occurrences of \`${symbol}\` found** (${result.multipleOccurrences.length} matches)\n\n`;
+        output += `📍 **File**: ${filePath}\n\n`;
+        output += `Use the \`codeSnippet\` parameter with a unique code fragment from the correct occurrence to disambiguate.\n\n`;
+        output += `**Occurrences:**\n`;
+        result.multipleOccurrences.forEach((match, index) => {
+          const lineNum = match.line + 1; // display as 1-indexed
+          output += `\n  **${index + 1}.** Line ${lineNum}:\n`;
+          output += `    \`${match.lineContent.trim()}\`\n`;
+        });
+        return {
+          content: [{
+            type: "text" as const,
+            text: output
+          }]
+        };
+      }
+
       // Format the comprehensive results
       let output = `🔍 **Symbol LSP Information: \`${symbol}\`**\n\n`;
       output += `📍 **File**: ${filePath}\n`;


### PR DESCRIPTION
When get_symbol_lsp_info encounters multiple occurrences of a symbol (without codeSnippet), it currently throws an unhelpful error forcing LLMs to guess codeSnippet values through trial and error.

Instead, return a structured list of all matching occurrences with their line numbers and code context. This lets the caller pick the correct occurrence and refine their query with codeSnippet.

Changes:
- resolve-symbol-position.ts: add resolveSymbolPositionOrListMatches() that returns all matches with line context instead of throwing
- get-symbol-lsp-info.ts (bridge): use new resolver, return multipleOccurrences when multiple matches found
- get-symbol-lsp-info.ts (ipc): extend output schema with multipleOccurrences field
- get-symbol-lsp-info.ts (server): format multiple occurrences as a helpful disambiguation list

Fixes #8