### PR TITLE
feat: add search workspace symbols functionality

### DIFF
--- a/packages/vscode-mcp-bridge/src/extension.ts
+++ b/packages/vscode-mcp-bridge/src/extension.ts
@@ -14,6 +14,8 @@ import {
     OpenFilesOutputSchema,
     RenameSymbolInputSchema,
     RenameSymbolOutputSchema,
+    SearchWorkspaceSymbolsInputSchema,
+    SearchWorkspaceSymbolsOutputSchema,
 } from '@vscode-mcp/vscode-mcp-ipc';
 import * as vscode from 'vscode';
 
@@ -33,6 +35,7 @@ getCurrentWorkspacePath,
     listWorkspaces,
     openFiles,
     renameSymbol,
+    searchWorkspaceSymbols,
 } from './services';
 import { SocketServer } from './socket-server';
 
@@ -108,6 +111,12 @@ export async function activate(context: vscode.ExtensionContext) {
         socketServer.register('listWorkspaces', {
             handler: listWorkspaces,
             resultSchema: ListWorkspacesOutputSchema
+        });
+
+        socketServer.register('searchWorkspaceSymbols', {
+            handler: searchWorkspaceSymbols,
+            payloadSchema: SearchWorkspaceSymbolsInputSchema,
+            resultSchema: SearchWorkspaceSymbolsOutputSchema
         });
         
         // Start socket server

--- a/packages/vscode-mcp-bridge/src/services/index.ts
+++ b/packages/vscode-mcp-bridge/src/services/index.ts
@@ -7,6 +7,7 @@ export { health } from './health';
 export { listWorkspaces } from './list-workspaces';
 export { openFiles } from './open-files';
 export { renameSymbol } from './rename-symbol';
+export { searchWorkspaceSymbols } from './workspace-symbol';
 
 // Export utilities
 export { getCurrentWorkspacePath } from '../utils/workspace.js'; 

--- a/packages/vscode-mcp-bridge/src/services/workspace-symbol.ts
+++ b/packages/vscode-mcp-bridge/src/services/workspace-symbol.ts
@@ -1,0 +1,30 @@
+import type { EventParams, EventResult } from '@vscode-mcp/vscode-mcp-ipc';
+import * as vscode from 'vscode';
+
+const toSymbolList = (symbols: vscode.SymbolInformation[] | undefined) =>
+    (symbols ?? []).map(s => ({
+        name: s.name,
+        kind: s.kind,
+        containerName: s.containerName || undefined,
+        uri: s.location.uri.toString(),
+        range: {
+            start: { line: s.location.range.start.line, character: s.location.range.start.character },
+            end: { line: s.location.range.end.line, character: s.location.range.end.character },
+        },
+    }));
+
+export const searchWorkspaceSymbols = async (
+    payload: EventParams<'searchWorkspaceSymbols'>
+): Promise<EventResult<'searchWorkspaceSymbols'>> => {
+    const results = await Promise.all(
+        payload.queries.map(async query => {
+            const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+                'vscode.executeWorkspaceSymbolProvider',
+                query
+            );
+            return { query, symbols: toSymbolList(symbols) };
+        })
+    );
+
+    return { results };
+};

--- a/packages/vscode-mcp-ipc/src/events/index.ts
+++ b/packages/vscode-mcp-ipc/src/events/index.ts
@@ -7,6 +7,7 @@ import type { HealthCheckPayload, HealthCheckResult } from './health-check.js';
 import type { ListWorkspacesPayload, ListWorkspacesResult } from './list-workspaces.js';
 import type { OpenFilesPayload, OpenFilesResult } from './open-file.js';
 import type { RenameSymbolPayload, RenameSymbolResult } from './rename-symbol.js';
+import type { SearchWorkspaceSymbolsPayload, SearchWorkspaceSymbolsResult } from './workspace-symbol.js';
 
 // Re-export all event types and schemas
 export * from '../common.js';
@@ -18,6 +19,7 @@ export * from './health-check.js';
 export * from './list-workspaces.js';
 export * from './open-file.js';
 export * from './rename-symbol.js';
+export * from './workspace-symbol.js';
 
 /**
  * Base request structure
@@ -95,6 +97,12 @@ export interface EventMap {
   listWorkspaces: {
     params: ListWorkspacesPayload;
     result: ListWorkspacesResult;
+  };
+
+  /** Search workspace symbols by name/pattern */
+  searchWorkspaceSymbols: {
+    params: SearchWorkspaceSymbolsPayload;
+    result: SearchWorkspaceSymbolsResult;
   };
 }
 

--- a/packages/vscode-mcp-ipc/src/events/workspace-symbol.ts
+++ b/packages/vscode-mcp-ipc/src/events/workspace-symbol.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+import { RangeSchema } from '../common.js';
+
+export const SearchWorkspaceSymbolsInputSchema = z
+  .object({
+    queries: z.array(z.string()).min(1).describe('One or more symbol names or patterns to search for across the workspace'),
+  })
+  .strict();
+
+const WorkspaceSymbolSchema = z
+  .object({
+    name: z.string(),
+    kind: z.number().describe('VSCode SymbolKind enum value (e.g. 5=Class, 11=Interface, 12=Function, 13=Variable)'),
+    containerName: z.string().optional().describe('Name of the enclosing symbol, if any'),
+    uri: z.string(),
+    range: RangeSchema,
+  })
+  .strict();
+
+const QueryResultSchema = z
+  .object({
+    query: z.string(),
+    symbols: z.array(WorkspaceSymbolSchema),
+  })
+  .strict();
+
+export const SearchWorkspaceSymbolsOutputSchema = z
+  .object({
+    results: z.array(QueryResultSchema),
+  })
+  .strict();
+
+export type SearchWorkspaceSymbolsPayload = z.infer<typeof SearchWorkspaceSymbolsInputSchema>;
+export type SearchWorkspaceSymbolsResult = z.infer<typeof SearchWorkspaceSymbolsOutputSchema>;

--- a/packages/vscode-mcp-server/src/constants.ts
+++ b/packages/vscode-mcp-server/src/constants.ts
@@ -13,6 +13,7 @@ export enum VscodeMcpToolName {
   LIST_WORKSPACES = 'list_workspaces',
   OPEN_FILES = 'open_files',
   RENAME_SYMBOL = 'rename_symbol',
+  SEARCH_WORKSPACE_SYMBOLS = 'search_workspace_symbols',
 }
 
 /**

--- a/packages/vscode-mcp-server/src/server.ts
+++ b/packages/vscode-mcp-server/src/server.ts
@@ -10,6 +10,7 @@ import {
   registerListWorkspaces,
   registerOpenFiles,
   registerRenameSymbol,
+  registerSearchWorkspaceSymbols,
 } from "./tools/index.js";
 
 // Tool registration mapping
@@ -24,6 +25,7 @@ const TOOL_REGISTRY: Record<string, ToolRegistrationFunction> = {
   [VscodeMcpToolName.OPEN_FILES]: registerOpenFiles,
   [VscodeMcpToolName.RENAME_SYMBOL]: registerRenameSymbol,
   [VscodeMcpToolName.LIST_WORKSPACES]: registerListWorkspaces,
+  [VscodeMcpToolName.SEARCH_WORKSPACE_SYMBOLS]: registerSearchWorkspaceSymbols,
 };
 
 /**

--- a/packages/vscode-mcp-server/src/tools/index.ts
+++ b/packages/vscode-mcp-server/src/tools/index.ts
@@ -16,3 +16,4 @@ export { registerHealthCheck } from "./health-check.js";
 export { registerListWorkspaces } from "./list-workspaces.js";
 export { registerOpenFiles } from "./open-files.js";
 export { registerRenameSymbol } from "./rename-symbol.js";
+export { registerSearchWorkspaceSymbols } from "./search-workspace-symbols.js";

--- a/packages/vscode-mcp-server/src/tools/search-workspace-symbols.ts
+++ b/packages/vscode-mcp-server/src/tools/search-workspace-symbols.ts
@@ -1,0 +1,77 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createDispatcher, SearchWorkspaceSymbolsInputSchema } from "@vscode-mcp/vscode-mcp-ipc";
+
+import { VscodeMcpToolName } from "../constants.js";
+import { formatToolCallError } from "../utils/format-tool-call-error.js";
+import { workspacePathInputSchema } from "../utils/workspace-schema.js";
+
+const inputSchema = {
+  ...workspacePathInputSchema,
+  ...SearchWorkspaceSymbolsInputSchema.shape,
+};
+
+const DESCRIPTION = `Search for symbols (classes, functions, variables, interfaces, etc.) across the entire workspace by name or pattern. Supports batch queries to look up multiple symbols in one call.
+
+Results come from all installed language server extensions, so this covers not just your source files but also external dependencies indexed by the language server — for example, the Red Hat Java extension indexes all jar dependencies, allowing you to find classes like ObjectMapper or HttpClient and see which jar they come from.
+
+**Return Format:**
+One result entry per query, each containing the matched symbols with name, kind, container name, file URI and range.
+
+**Typical Use Cases:**
+- Find where a class/interface/function/variable is defined when you only know its name, without knowing which file it lives in
+- Locate the file path and exact line of any symbol across the entire codebase
+- Explore all symbols matching a prefix or partial name (e.g. query "User" to find UserService, UserController, UserDto, etc.)
+- Find which jar/library a Java class belongs to (e.g. query "ObjectMapper" → URI reveals it's in jackson-databind-x.x.x.jar)
+`;
+
+
+// VSCode SymbolKind enum labels for human-readable output
+const SYMBOL_KIND_LABELS: Record<number, string> = {
+  0: 'File', 1: 'Module', 2: 'Namespace', 3: 'Package', 4: 'Class',
+  5: 'Method', 6: 'Property', 7: 'Field', 8: 'Constructor', 9: 'Enum',
+  10: 'Interface', 11: 'Function', 12: 'Variable', 13: 'Constant',
+  14: 'String', 15: 'Number', 16: 'Boolean', 17: 'Array', 18: 'Object',
+  19: 'Key', 20: 'Null', 21: 'EnumMember', 22: 'Struct', 23: 'Event',
+  24: 'Operator', 25: 'TypeParameter',
+};
+
+export function registerSearchWorkspaceSymbols(server: McpServer) {
+  server.registerTool(VscodeMcpToolName.SEARCH_WORKSPACE_SYMBOLS, {
+    title: "Search Workspace Symbols",
+    description: DESCRIPTION,
+    inputSchema,
+    annotations: {
+      title: "Search Workspace Symbols",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, async ({ workspace_path, queries }) => {
+    try {
+      const dispatcher = await createDispatcher(workspace_path);
+      const result = await dispatcher.dispatch("searchWorkspaceSymbols", { queries });
+
+      const sections = result.results.map(({ query, symbols }) => {
+        if (symbols.length === 0) {
+          return `## "${query}"\nNo symbols found.`;
+        }
+        const lines = symbols.map(s => {
+          const kind = SYMBOL_KIND_LABELS[s.kind] ?? `Kind(${s.kind})`;
+          const container = s.containerName ? ` [in ${s.containerName}]` : '';
+          return `${kind} ${s.name}${container}\n  ${s.uri} @ ${s.range.start.line}:${s.range.start.character}`;
+        });
+        return `## "${query}" — ${symbols.length} symbol(s)\n\n${lines.join('\n\n')}`;
+      });
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: sections.join('\n\n---\n\n'),
+        }],
+      };
+    } catch (error) {
+      return formatToolCallError("Search Workspace Symbols", error);
+    }
+  });
+}


### PR DESCRIPTION
- Implemented the searchWorkspaceSymbols service to allow searching for symbols across the workspace by name or pattern.
- Added corresponding input and output schemas for the new service.
- Registered the searchWorkspaceSymbols tool in the MCP server for handling requests.
- Updated the extension to register the new service with the socket server.

This feature enhances the ability to locate symbols in the codebase, improving developer productivity.

Fixes https://github.com/tjx666/vscode-mcp/issues/5