### PR TITLE
feat: add list_open_editors and close_editors tools

### DIFF
--- a/packages/vscode-mcp-bridge/src/extension.ts
+++ b/packages/vscode-mcp-bridge/src/extension.ts
@@ -9,6 +9,8 @@ import {
     GetSymbolLSPInfoOutputSchema,
     HealthCheckInputSchema,
     HealthCheckOutputSchema,
+    ListOpenEditorsInputSchema,
+    ListOpenEditorsOutputSchema,
     ListWorkspacesOutputSchema,
     OpenFilesInputSchema,
     OpenFilesOutputSchema,
@@ -30,6 +32,7 @@ import {
     getReferences,
     getSymbolLSPInfo,
     health,
+    listOpenEditors,
     listWorkspaces,
     openFiles,
     renameSymbol,
@@ -108,6 +111,12 @@ export async function activate(context: vscode.ExtensionContext) {
         socketServer.register('listWorkspaces', {
             handler: listWorkspaces,
             resultSchema: ListWorkspacesOutputSchema,
+        });
+
+        socketServer.register('listOpenEditors', {
+            handler: listOpenEditors,
+            payloadSchema: ListOpenEditorsInputSchema,
+            resultSchema: ListOpenEditorsOutputSchema,
         });
 
         // Start socket server

--- a/packages/vscode-mcp-bridge/src/extension.ts
+++ b/packages/vscode-mcp-bridge/src/extension.ts
@@ -1,4 +1,6 @@
 import {
+    CloseEditorsInputSchema,
+    CloseEditorsOutputSchema,
     ExecuteCommandInputSchema,
     ExecuteCommandOutputSchema,
     GetDiagnosticsInputSchema,
@@ -26,6 +28,7 @@ import { copyOpenedFilesPathCommand } from './commands/copy-opened-files-path';
 import { sleepCommand } from './commands/sleep';
 import { logger } from './logger';
 import {
+    closeEditors,
     executeCommand,
     getCurrentWorkspacePath,
     getDiagnostics,
@@ -117,6 +120,12 @@ export async function activate(context: vscode.ExtensionContext) {
             handler: listOpenEditors,
             payloadSchema: ListOpenEditorsInputSchema,
             resultSchema: ListOpenEditorsOutputSchema,
+        });
+
+        socketServer.register('closeEditors', {
+            handler: closeEditors,
+            payloadSchema: CloseEditorsInputSchema,
+            resultSchema: CloseEditorsOutputSchema,
         });
 
         // Start socket server

--- a/packages/vscode-mcp-bridge/src/services/close-editors.ts
+++ b/packages/vscode-mcp-bridge/src/services/close-editors.ts
@@ -41,7 +41,11 @@ export const closeEditors = async (
   const tabsToClose: vscode.Tab[] = [];
 
   for (const requested of paths) {
-    const matching = allTabs.filter((tab) => tabFsPath(tab.input) === requested);
+    // Normalize the requested path the way VSCode stores tab URIs (separators,
+    // `.`-segments, trailing slash) so matching is robust. Case is left as-is —
+    // we match VSCode's stored on-disk case.
+    const target = vscode.Uri.file(requested).fsPath;
+    const matching = allTabs.filter((tab) => tabFsPath(tab.input) === target);
     if (matching.length === 0) {
       notFound.push(requested);
       continue;
@@ -50,8 +54,11 @@ export const closeEditors = async (
     if (closeable.length > 0) {
       tabsToClose.push(...closeable);
       closed.push(requested);
-    } else {
-      // every matching tab is dirty and forceCloseDirty is false
+    }
+    // Flag a path that still has ANY unsaved tab left open — even if a clean
+    // copy in another group was closed — so a partial close never silently
+    // hides an unsaved tab. A path may therefore appear in both lists.
+    if (!forceCloseDirty && matching.some((tab) => tab.isDirty)) {
       skippedDirty.push(requested);
     }
   }

--- a/packages/vscode-mcp-bridge/src/services/close-editors.ts
+++ b/packages/vscode-mcp-bridge/src/services/close-editors.ts
@@ -1,0 +1,74 @@
+import type { EventParams, EventResult } from '@vscode-mcp/vscode-mcp-ipc';
+import * as vscode from 'vscode';
+
+/**
+ * Resolve the on-disk path a tab points at, for tab kinds that have one.
+ * Mirrors the kind handling in list-open-editors; diff tabs match on their
+ * modified side.
+ */
+function tabFsPath(input: unknown): string | undefined {
+  if (input instanceof vscode.TabInputText) {
+    return input.uri.fsPath;
+  }
+  if (input instanceof vscode.TabInputTextDiff) {
+    return input.modified.fsPath;
+  }
+  if (input instanceof vscode.TabInputNotebook) {
+    return input.uri.fsPath;
+  }
+  if (input instanceof vscode.TabInputNotebookDiff) {
+    return input.modified.fsPath;
+  }
+  if (input instanceof vscode.TabInputCustom) {
+    return input.uri.fsPath;
+  }
+  return undefined;
+}
+
+/**
+ * Close the editor tabs for the given file paths.
+ */
+export const closeEditors = async (
+  payload: EventParams<'closeEditors'>,
+): Promise<EventResult<'closeEditors'>> => {
+  const { paths, forceCloseDirty } = payload;
+
+  const allTabs = vscode.window.tabGroups.all.flatMap((group) => group.tabs);
+
+  const closed: string[] = [];
+  const skippedDirty: string[] = [];
+  const notFound: string[] = [];
+  const tabsToClose: vscode.Tab[] = [];
+
+  for (const requested of paths) {
+    const matching = allTabs.filter((tab) => tabFsPath(tab.input) === requested);
+    if (matching.length === 0) {
+      notFound.push(requested);
+      continue;
+    }
+    const closeable = forceCloseDirty ? matching : matching.filter((tab) => !tab.isDirty);
+    if (closeable.length > 0) {
+      tabsToClose.push(...closeable);
+      closed.push(requested);
+    } else {
+      // every matching tab is dirty and forceCloseDirty is false
+      skippedDirty.push(requested);
+    }
+  }
+
+  if (tabsToClose.length > 0) {
+    await vscode.window.tabGroups.close(tabsToClose, true);
+  }
+
+  return {
+    closed,
+    skipped_dirty: skippedDirty,
+    not_found: notFound,
+    summary: {
+      requested: paths.length,
+      closed: closed.length,
+      skipped_dirty: skippedDirty.length,
+      not_found: notFound.length,
+    },
+  };
+};

--- a/packages/vscode-mcp-bridge/src/services/index.ts
+++ b/packages/vscode-mcp-bridge/src/services/index.ts
@@ -4,6 +4,7 @@ export { getDiagnostics } from './get-diagnostics';
 export { getReferences } from './get-references';
 export { getSymbolLSPInfo } from './get-symbol-lsp-info';
 export { health } from './health';
+export { listOpenEditors } from './list-open-editors';
 export { listWorkspaces } from './list-workspaces';
 export { openFiles } from './open-files';
 export { renameSymbol } from './rename-symbol';

--- a/packages/vscode-mcp-bridge/src/services/index.ts
+++ b/packages/vscode-mcp-bridge/src/services/index.ts
@@ -1,4 +1,5 @@
 // Export service functions
+export { closeEditors } from './close-editors';
 export { executeCommand } from './execute-command';
 export { getDiagnostics } from './get-diagnostics';
 export { getReferences } from './get-references';

--- a/packages/vscode-mcp-bridge/src/services/list-open-editors.ts
+++ b/packages/vscode-mcp-bridge/src/services/list-open-editors.ts
@@ -1,0 +1,73 @@
+import type { EventParams, EventResult, OpenEditorTab } from '@vscode-mcp/vscode-mcp-ipc';
+import * as vscode from 'vscode';
+
+/**
+ * Classify a tab's input and pull out its resource URI when it has one.
+ *
+ * Enumerates ALL tab input kinds (not just file-scheme `TabInputText`) so the
+ * result includes diffs, notebooks, custom editors, untitled buffers,
+ * interactive windows, webviews and terminals — anything the user actually has
+ * open. Untitled buffers arrive as `TabInputText` with an `untitled:` scheme,
+ * so they are covered by the text branch.
+ */
+function describeTabInput(input: unknown): { kind: OpenEditorTab['kind']; uri?: string } {
+  if (input instanceof vscode.TabInputText) {
+    return { kind: 'text', uri: input.uri.toString() };
+  }
+  if (input instanceof vscode.TabInputTextDiff) {
+    return { kind: 'diff', uri: input.modified.toString() };
+  }
+  if (input instanceof vscode.TabInputNotebook) {
+    return { kind: 'notebook', uri: input.uri.toString() };
+  }
+  if (input instanceof vscode.TabInputNotebookDiff) {
+    return { kind: 'notebook-diff', uri: input.modified.toString() };
+  }
+  if (input instanceof vscode.TabInputCustom) {
+    return { kind: 'custom', uri: input.uri.toString() };
+  }
+  if (input instanceof vscode.TabInputWebview) {
+    return { kind: 'webview' };
+  }
+  if (input instanceof vscode.TabInputTerminal) {
+    return { kind: 'terminal' };
+  }
+  return { kind: 'other' };
+}
+
+/**
+ * List every open editor tab across all tab groups in this window.
+ */
+export const listOpenEditors = async (
+  _payload: EventParams<'listOpenEditors'>,
+): Promise<EventResult<'listOpenEditors'>> => {
+  const groups = vscode.window.tabGroups.all;
+  const editors: OpenEditorTab[] = [];
+
+  groups.forEach((group, groupIndex) => {
+    for (const tab of group.tabs) {
+      const { kind, uri } = describeTabInput(tab.input);
+      editors.push({
+        label: tab.label,
+        uri,
+        kind,
+        group_index: groupIndex,
+        is_active: tab.isActive,
+        is_dirty: tab.isDirty,
+        is_pinned: tab.isPinned,
+        is_preview: tab.isPreview,
+      });
+    }
+  });
+
+  const activeGroupIndex = groups.findIndex((group) => group.isActive);
+
+  return {
+    editors,
+    summary: {
+      total: editors.length,
+      groups: groups.length,
+      active_group_index: activeGroupIndex >= 0 ? activeGroupIndex : undefined,
+    },
+  };
+};

--- a/packages/vscode-mcp-core/src/tools/close-editors.ts
+++ b/packages/vscode-mcp-core/src/tools/close-editors.ts
@@ -1,0 +1,68 @@
+import { createDispatcher, CloseEditorsInputSchema } from '@vscode-mcp/vscode-mcp-ipc';
+
+import type { ToolDefinition } from '../types.js';
+
+const DESCRIPTION = `Close one or more open editor tabs by file path.
+
+Closes the tab(s) for each given absolute path across all tab groups. There is
+no built-in VSCode command that closes a *specific* file by path, so this is the
+counterpart to open_files (open/focus) and list_open_editors (enumerate).
+
+**Safety:** by default, tabs with unsaved changes are NOT closed — they are
+returned in \`skipped_dirty\`. Set \`forceCloseDirty: true\` only when you
+intend to discard those unsaved changes.
+
+Pair with list_open_editors to discover what's open first.`;
+
+export const closeEditorsTool: ToolDefinition<typeof CloseEditorsInputSchema> = {
+  name: 'close_editors',
+  cliName: 'close-editors',
+  title: 'Close Editors',
+  description: DESCRIPTION,
+  schema: CloseEditorsInputSchema,
+  requiresWorkspace: true,
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  cli: {
+    // `paths` is a string array; expose it as a variadic flag plus a boolean.
+    options: [
+      {
+        flags: '--paths <paths...>',
+        description: 'One or more absolute file paths whose tabs should be closed',
+      },
+      {
+        flags: '--force-close-dirty',
+        description: 'Also close tabs with unsaved changes (discards them)',
+      },
+    ],
+    transform: (cliArgs) => ({
+      paths: (cliArgs.paths as string[]) ?? [],
+      forceCloseDirty: cliArgs.forceCloseDirty === true,
+    }),
+  },
+  async handler(params, { workspacePath }) {
+    const dispatcher = await createDispatcher(workspacePath);
+    const result = await dispatcher.dispatch('closeEditors', {
+      paths: params.paths,
+      forceCloseDirty: params.forceCloseDirty,
+    });
+
+    const lines: string[] = [];
+    if (result.closed.length > 0) {
+      lines.push(`✅ Closed ${result.closed.length}: ${result.closed.join(', ')}`);
+    }
+    if (result.skipped_dirty.length > 0) {
+      lines.push(
+        `⚠️ Skipped (unsaved — not closed): ${result.skipped_dirty.join(', ')}`,
+      );
+    }
+    if (result.not_found.length > 0) {
+      lines.push(`🔍 Not open (no matching tab): ${result.not_found.join(', ')}`);
+    }
+    return lines.length > 0 ? lines.join('\n') : 'No matching open editors to close.';
+  },
+};

--- a/packages/vscode-mcp-core/src/tools/index.ts
+++ b/packages/vscode-mcp-core/src/tools/index.ts
@@ -4,6 +4,7 @@ import { getDiagnosticsTool } from './get-diagnostics.js';
 import { getReferencesTool } from './get-references.js';
 import { getSymbolLspInfoTool } from './get-symbol-lsp-info.js';
 import { createHealthCheckTool } from './health-check.js';
+import { listOpenEditorsTool } from './list-open-editors.js';
 import { listWorkspacesTool } from './list-workspaces.js';
 import { openFilesTool } from './open-files.js';
 import { renameSymbolTool } from './rename-symbol.js';
@@ -13,6 +14,7 @@ export { getDiagnosticsTool } from './get-diagnostics.js';
 export { getReferencesTool } from './get-references.js';
 export { getSymbolLspInfoTool } from './get-symbol-lsp-info.js';
 export { createHealthCheckTool } from './health-check.js';
+export { listOpenEditorsTool } from './list-open-editors.js';
 export { listWorkspacesTool } from './list-workspaces.js';
 export { openFilesTool } from './open-files.js';
 export { renameSymbolTool } from './rename-symbol.js';
@@ -31,5 +33,6 @@ export function getAllTools(opts: { clientVersion: string }): AnyToolDefinition[
     openFilesTool as AnyToolDefinition,
     renameSymbolTool as AnyToolDefinition,
     listWorkspacesTool as AnyToolDefinition,
+    listOpenEditorsTool as AnyToolDefinition,
   ];
 }

--- a/packages/vscode-mcp-core/src/tools/index.ts
+++ b/packages/vscode-mcp-core/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { AnyToolDefinition } from '../types.js';
+import { closeEditorsTool } from './close-editors.js';
 import { executeCommandTool } from './execute-command.js';
 import { getDiagnosticsTool } from './get-diagnostics.js';
 import { getReferencesTool } from './get-references.js';
@@ -13,6 +14,7 @@ export { executeCommandTool } from './execute-command.js';
 export { getDiagnosticsTool } from './get-diagnostics.js';
 export { getReferencesTool } from './get-references.js';
 export { getSymbolLspInfoTool } from './get-symbol-lsp-info.js';
+export { closeEditorsTool } from './close-editors.js';
 export { createHealthCheckTool } from './health-check.js';
 export { listOpenEditorsTool } from './list-open-editors.js';
 export { listWorkspacesTool } from './list-workspaces.js';
@@ -34,5 +36,6 @@ export function getAllTools(opts: { clientVersion: string }): AnyToolDefinition[
     renameSymbolTool as AnyToolDefinition,
     listWorkspacesTool as AnyToolDefinition,
     listOpenEditorsTool as AnyToolDefinition,
+    closeEditorsTool as AnyToolDefinition,
   ];
 }

--- a/packages/vscode-mcp-core/src/tools/list-open-editors.ts
+++ b/packages/vscode-mcp-core/src/tools/list-open-editors.ts
@@ -1,0 +1,62 @@
+import { createDispatcher, ListOpenEditorsInputSchema } from '@vscode-mcp/vscode-mcp-ipc';
+
+import type { ToolDefinition } from '../types.js';
+
+const DESCRIPTION = `List all open editor tabs in a VSCode window as structured data.
+
+Returns every tab across all tab groups (editor columns) — not just text files,
+but also diffs, notebooks, custom editors, untitled buffers, interactive
+windows, webviews and terminals. Each entry reports its label, resource URI
+(when it has one), kind, tab group index, and active/dirty/pinned/preview flags.
+
+**When to use:**
+- See which files the user already has open before opening more
+- Find the active editor / dirty (unsaved) buffers
+- Understand the user's current editor layout
+
+**Note:** Pair with \`open_files\` to open or focus a file in the same window.`;
+
+export const listOpenEditorsTool: ToolDefinition<typeof ListOpenEditorsInputSchema> = {
+  name: 'list_open_editors',
+  cliName: 'list-open-editors',
+  title: 'List Open Editors',
+  description: DESCRIPTION,
+  schema: ListOpenEditorsInputSchema,
+  requiresWorkspace: true,
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  async handler(_params, { workspacePath }) {
+    const dispatcher = await createDispatcher(workspacePath);
+    const result = await dispatcher.dispatch('listOpenEditors', {});
+
+    if (result.editors.length === 0) {
+      return '📭 No open editor tabs in this window.';
+    }
+
+    const lines = result.editors.map((editor) => {
+      const flags = [
+        editor.is_active ? 'active' : null,
+        editor.is_dirty ? 'dirty' : null,
+        editor.is_pinned ? 'pinned' : null,
+        editor.is_preview ? 'preview' : null,
+      ]
+        .filter(Boolean)
+        .join(', ');
+      const location = editor.uri ?? '(no uri)';
+      const suffix = flags ? ` (${flags})` : '';
+      return `- [group ${editor.group_index}] ${editor.kind}: ${editor.label} — ${location}${suffix}`;
+    });
+
+    const { total, groups, active_group_index } = result.summary;
+    const header =
+      `📑 ${total} open editor tab(s) across ${groups} group(s)` +
+      (active_group_index === undefined ? '' : ` (active group: ${active_group_index})`) +
+      ':';
+
+    return `${header}\n${lines.join('\n')}`;
+  },
+};

--- a/packages/vscode-mcp-core/src/tools/list-open-editors.ts
+++ b/packages/vscode-mcp-core/src/tools/list-open-editors.ts
@@ -5,8 +5,8 @@ import type { ToolDefinition } from '../types.js';
 const DESCRIPTION = `List all open editor tabs in a VSCode window as structured data.
 
 Returns every tab across all tab groups (editor columns) — not just text files,
-but also diffs, notebooks, custom editors, untitled buffers, interactive
-windows, webviews and terminals. Each entry reports its label, resource URI
+but also diffs, notebooks, custom editors, untitled buffers, webviews and
+terminals. Each entry reports its label, resource URI
 (when it has one), kind, tab group index, and active/dirty/pinned/preview flags.
 
 **When to use:**

--- a/packages/vscode-mcp-ipc/src/events/close-editors.ts
+++ b/packages/vscode-mcp-ipc/src/events/close-editors.ts
@@ -1,0 +1,56 @@
+/**
+ * Close editors event types and schemas
+ */
+
+import { z } from 'zod';
+
+/**
+ * Close editors input schema
+ */
+export const CloseEditorsInputSchema = z
+  .object({
+    paths: z
+      .array(z.string())
+      .min(1)
+      .describe('Absolute file paths whose editor tabs should be closed. Matched against open tab URIs across all tab groups.'),
+    forceCloseDirty: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'When true, also close tabs that have unsaved changes — the changes are DISCARDED. Default false: dirty tabs are left open and reported in skipped_dirty.',
+      ),
+  })
+  .strict();
+
+/**
+ * Close editors output schema
+ */
+export const CloseEditorsOutputSchema = z
+  .object({
+    closed: z.array(z.string()).describe('Paths whose tab(s) were closed'),
+    skipped_dirty: z
+      .array(z.string())
+      .describe('Paths left open because they had unsaved changes and forceCloseDirty was false'),
+    not_found: z.array(z.string()).describe('Requested paths that had no matching open tab'),
+    summary: z
+      .object({
+        requested: z.number().describe('Number of paths requested'),
+        closed: z.number().describe('Number of paths closed'),
+        skipped_dirty: z.number().describe('Number of paths skipped due to unsaved changes'),
+        not_found: z.number().describe('Number of paths with no open tab'),
+      })
+      .strict()
+      .describe('Summary statistics'),
+  })
+  .strict();
+
+/**
+ * Close editors payload (input parameters)
+ */
+export type CloseEditorsPayload = z.infer<typeof CloseEditorsInputSchema>;
+
+/**
+ * Close editors result (output data)
+ */
+export type CloseEditorsResult = z.infer<typeof CloseEditorsOutputSchema>;

--- a/packages/vscode-mcp-ipc/src/events/close-editors.ts
+++ b/packages/vscode-mcp-ipc/src/events/close-editors.ts
@@ -28,10 +28,12 @@ export const CloseEditorsInputSchema = z
  */
 export const CloseEditorsOutputSchema = z
   .object({
-    closed: z.array(z.string()).describe('Paths whose tab(s) were closed'),
+    closed: z.array(z.string()).describe('Paths for which at least one tab was closed'),
     skipped_dirty: z
       .array(z.string())
-      .describe('Paths left open because they had unsaved changes and forceCloseDirty was false'),
+      .describe(
+        'Paths that still have at least one unsaved tab left open (forceCloseDirty was false). A path may also appear in `closed` if a clean copy in another tab group was closed.',
+      ),
     not_found: z.array(z.string()).describe('Requested paths that had no matching open tab'),
     summary: z
       .object({

--- a/packages/vscode-mcp-ipc/src/events/index.ts
+++ b/packages/vscode-mcp-ipc/src/events/index.ts
@@ -4,6 +4,7 @@ import type { GetDiagnosticsPayload, GetDiagnosticsResult } from './get-diagnost
 import type { GetReferencesPayload, GetReferencesResult } from './get-references.js';
 import type { GetSymbolLSPInfoPayload, GetSymbolLSPInfoResult } from './get-symbol-lsp-info.js';
 import type { HealthCheckPayload, HealthCheckResult } from './health-check.js';
+import type { ListOpenEditorsPayload, ListOpenEditorsResult } from './list-open-editors.js';
 import type { ListWorkspacesPayload, ListWorkspacesResult } from './list-workspaces.js';
 import type { OpenFilesPayload, OpenFilesResult } from './open-file.js';
 import type { RenameSymbolPayload, RenameSymbolResult } from './rename-symbol.js';
@@ -15,6 +16,7 @@ export * from './get-diagnostics.js';
 export * from './get-references.js';
 export * from './get-symbol-lsp-info.js';
 export * from './health-check.js';
+export * from './list-open-editors.js';
 export * from './list-workspaces.js';
 export * from './open-file.js';
 export * from './rename-symbol.js';
@@ -95,6 +97,13 @@ export interface EventMap {
   listWorkspaces: {
     params: ListWorkspacesPayload;
     result: ListWorkspacesResult;
+  };
+
+
+  /** List open editor tabs */
+  listOpenEditors: {
+    params: ListOpenEditorsPayload;
+    result: ListOpenEditorsResult;
   };
 }
 

--- a/packages/vscode-mcp-ipc/src/events/index.ts
+++ b/packages/vscode-mcp-ipc/src/events/index.ts
@@ -1,4 +1,5 @@
 // Import all event modules
+import type { CloseEditorsPayload, CloseEditorsResult } from './close-editors.js';
 import type { ExecuteCommandPayload, ExecuteCommandResult } from './execute-command.js';
 import type { GetDiagnosticsPayload, GetDiagnosticsResult } from './get-diagnostics.js';
 import type { GetReferencesPayload, GetReferencesResult } from './get-references.js';
@@ -11,6 +12,7 @@ import type { RenameSymbolPayload, RenameSymbolResult } from './rename-symbol.js
 
 // Re-export all event types and schemas
 export * from '../common.js';
+export * from './close-editors.js';
 export * from './execute-command.js';
 export * from './get-diagnostics.js';
 export * from './get-references.js';
@@ -104,6 +106,13 @@ export interface EventMap {
   listOpenEditors: {
     params: ListOpenEditorsPayload;
     result: ListOpenEditorsResult;
+  };
+
+
+  /** Close editor tabs by path */
+  closeEditors: {
+    params: CloseEditorsPayload;
+    result: CloseEditorsResult;
   };
 }
 

--- a/packages/vscode-mcp-ipc/src/events/list-open-editors.ts
+++ b/packages/vscode-mcp-ipc/src/events/list-open-editors.ts
@@ -1,0 +1,80 @@
+/**
+ * List open editors event types and schemas
+ */
+
+import { z } from 'zod';
+
+/**
+ * List open editors input schema (no parameters — the bound window is implied
+ * by the workspace_path the MCP/CLI adapter uses to pick the socket).
+ */
+export const ListOpenEditorsInputSchema = z.object({}).strict();
+
+/**
+ * A single open editor tab.
+ */
+export const OpenEditorTabSchema = z
+  .object({
+    label: z.string().describe('Tab label as shown in the VSCode UI'),
+    uri: z
+      .string()
+      .optional()
+      .describe(
+        'Resource URI of the tab when it has one (file/untitled/notebook/custom). Diff tabs report the modified-side URI. Webview/terminal tabs have none.',
+      ),
+    kind: z
+      .enum([
+        'text',
+        'diff',
+        'notebook',
+        'notebook-diff',
+        'custom',
+        'webview',
+        'terminal',
+        'other',
+      ])
+      .describe('Kind of tab input'),
+    group_index: z.number().describe('Index of the tab group (editor column) this tab belongs to'),
+    is_active: z.boolean().describe('Whether this is the active tab in its group'),
+    is_dirty: z.boolean().describe('Whether the tab has unsaved changes'),
+    is_pinned: z.boolean().describe('Whether the tab is pinned'),
+    is_preview: z.boolean().describe('Whether the tab is a preview (italic, single-click) tab'),
+  })
+  .strict();
+
+/**
+ * List open editors output schema
+ */
+export const ListOpenEditorsOutputSchema = z
+  .object({
+    editors: z
+      .array(OpenEditorTabSchema)
+      .describe('Every open editor tab across all tab groups, in group/tab order'),
+    summary: z
+      .object({
+        total: z.number().describe('Total number of open tabs'),
+        groups: z.number().describe('Number of tab groups (editor columns)'),
+        active_group_index: z
+          .number()
+          .optional()
+          .describe('Index of the active tab group, if any'),
+      })
+      .strict()
+      .describe('Summary statistics'),
+  })
+  .strict();
+
+/**
+ * List open editors payload (input parameters)
+ */
+export type ListOpenEditorsPayload = z.infer<typeof ListOpenEditorsInputSchema>;
+
+/**
+ * List open editors result (output data)
+ */
+export type ListOpenEditorsResult = z.infer<typeof ListOpenEditorsOutputSchema>;
+
+/**
+ * Single open editor tab type
+ */
+export type OpenEditorTab = z.infer<typeof OpenEditorTabSchema>;


### PR DESCRIPTION
## Summary

Adds two complementary editor-tab-management tools. Neither has a built-in VSCode command equivalent, so both need real bridge services.

- **`list_open_editors`** — return every open editor tab (across all tab groups) as structured data.
- **`close_editors`** — close editor tab(s) by file path (dirty-safe by default).

Together with the existing `open_files` (open/focus), these give an agent the full open → inspect → close loop over the editor.

## `list_open_editors`

`open_files` opens/focuses a file, but an agent otherwise can't **see what's already open**. This returns, per tab — iterating `vscode.window.tabGroups.all`:

- `label`, `uri` (when the input has one)
- `kind` — `text` / `diff` / `notebook` / `notebook-diff` / `custom` / `webview` / `terminal` / `other` (enumerates **all** `TabInput*` kinds, not just file-scheme `TabInputText`, so diffs, notebooks, custom editors and untitled buffers are included)
- `group_index`, `is_active`, `is_dirty`, `is_pinned`, `is_preview`
- plus a `summary` (`total`, `groups`, `active_group_index`)

`requiresWorkspace: true`, read-only.

## `close_editors`

Closes the tab(s) for each given absolute path via `vscode.window.tabGroups.close(...)`. There's no built-in command that closes a *specific* file by path (`execute_command` only reaches `closeActiveEditor` / `closeAllEditors`).

- `paths: string[]` — files whose tabs to close
- `forceCloseDirty?: boolean` (default **false**) — when false, tabs with unsaved changes are left open and reported in `skipped_dirty`; set true only to discard unsaved changes
- returns `closed` / `skipped_dirty` / `not_found` + a `summary`
- `requiresWorkspace: true`, `destructiveHint: true`

## Changes

Both follow the IPC → bridge → core add-a-tool pattern in `.cursor/rules/vscode-mcp-development-guide.mdc`; server/CLI auto-pick-up via `getAllTools()` (no server/cli changes).

| File | list_open_editors | close_editors |
|------|:---:|:---:|
| `vscode-mcp-ipc/src/events/*.ts` (+ `events/index.ts`) | ✓ | ✓ |
| `vscode-mcp-bridge/src/services/*.ts` (+ `services/index.ts`, `extension.ts`) | ✓ | ✓ |
| `vscode-mcp-core/src/tools/*.ts` (+ `tools/index.ts`) | ✓ | ✓ |

## Test plan

- [x] `pnpm -r build` clean; bridge `tsc --noEmit` typecheck clean
- [x] Tool enumeration shows both tools (`requiresWorkspace: true`) alongside the existing set
- [x] Exercised end-to-end against a live bridge via the CLI:
  - `list_open_editors` returns the real tab list with correct active/dirty/preview flags across groups
  - `close_editors` closes a tab by path (list goes 3 → 2), reports `not_found` for an unopened path, and leaves dirty tabs untouched by default

> Developed while building a small downstream fork; happy to split into two PRs, or to adjust naming / output shape / annotations to your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)